### PR TITLE
Logging Framework switched frome log4j to slf4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,9 +74,14 @@
             <version>[0.11,0.14-SNAPSHOT)</version>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.21</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>1.7.21</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/examples/Cross_lib_provider.java
+++ b/src/main/java/examples/Cross_lib_provider.java
@@ -2,8 +2,6 @@ package examples;
 
 import static java.lang.Math.cos;
 import static java.lang.Math.sin;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.media.j3d.Transform3D;
@@ -19,7 +17,6 @@ import rct.TransformReceiver;
 import rct.TransformType;
 import rct.TransformerException;
 import rct.TransformerFactory;
-import rct.impl.rsb.TransformCommunicatorRSB;
 
 /**
  *

--- a/src/main/java/rct/impl/TransformCacheImpl.java
+++ b/src/main/java/rct/impl/TransformCacheImpl.java
@@ -2,12 +2,12 @@ package rct.impl;
 
 import java.util.LinkedList;
 import java.util.List;
-
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TransformCacheImpl implements TransformCache {
 
-	private Logger logger = Logger.getLogger(TransformCacheImpl.class);
+	private static Logger logger = LoggerFactory.getLogger(TransformCacheImpl.class);
 	private long maxStorageTime;
 	private List<TransformInternal> storage_ = new LinkedList<TransformInternal>();
 

--- a/src/main/java/rct/impl/TransformCacheStatic.java
+++ b/src/main/java/rct/impl/TransformCacheStatic.java
@@ -1,11 +1,12 @@
 package rct.impl;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TransformCacheStatic implements TransformCache {
 
 	private TransformInternal storage = new TransformInternal();
-	private Logger logger = Logger.getLogger(TransformCacheImpl.class);
+	private static Logger logger = LoggerFactory.getLogger(TransformCacheImpl.class);
 	
 	public TransformCacheStatic() {
 	}

--- a/src/main/java/rct/impl/TransformerCoreDefault.java
+++ b/src/main/java/rct/impl/TransformerCoreDefault.java
@@ -15,8 +15,8 @@ import javax.media.j3d.Transform3D;
 import javax.vecmath.Matrix3d;
 import javax.vecmath.Quat4d;
 import javax.vecmath.Vector3d;
-
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import rct.Transform;
 import rct.TransformerException;
@@ -128,8 +128,7 @@ public class TransformerCoreDefault implements TransformerCore {
 
 	private static final int MAX_GRAPH_DEPTH = 1000;
 
-	private static Logger logger = Logger
-			.getLogger(TransformerCoreDefault.class);
+	private static Logger logger = LoggerFactory.getLogger(TransformerCoreDefault.class);
 	private Object lock = new Object();
 	private Map<String, Integer> frameIds = new HashMap<String, Integer>();
 	private List<TransformCache> frames = new LinkedList<TransformCache>();
@@ -943,8 +942,7 @@ public class TransformerCoreDefault implements TransformerCore {
 		try {
 			setTransform(transform, isStatic);
 		} catch (TransformerException e) {
-			logger.error(e.getMessage());
-			logger.debug(e);
+			logger.error(e.getMessage(), e);
 		}
 	}
 }

--- a/src/main/java/rct/impl/rsb/TransformCommunicatorRSB.java
+++ b/src/main/java/rct/impl/rsb/TransformCommunicatorRSB.java
@@ -7,8 +7,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import rct.Transform;
 import rct.TransformType;
@@ -52,8 +52,7 @@ public class TransformCommunicatorRSB implements TransformCommunicator {
 	private ExecutorService executor = Executors.newCachedThreadPool();
 	private String name;
 
-	private static Logger logger = Logger
-			.getLogger(TransformCommunicatorRSB.class);
+	private static Logger logger = LoggerFactory.getLogger(TransformCommunicatorRSB.class);
 
 	public TransformCommunicatorRSB(String name) {
 		this.name = name;


### PR DESCRIPTION
Because slf4j is just a logging api and abstracts the logger back-end its much more flexible than log4j.
The logging framework can be flexible defined for each project and is not forced by any libs.
I just selected log4j as default backend (slf4j-log4j12).

more details: 
- http://www.slf4j.org/index.html
- http://javarevisited.blogspot.com/2013/08/why-use-sl4j-over-log4j-for-logging-in.html
